### PR TITLE
Enable Swagger UI using correct property key

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,4 +10,4 @@ quarkus.datasource.username = ${DB_USERNAME}
 quarkus.datasource.password= = ${DB_PASSWORD}
 quarkus.datasource.jdbc.url = ${DB_URL}
 
-quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.enable=true


### PR DESCRIPTION
Updated the property `quarkus.swagger-ui.always-include` to `quarkus.swagger-ui.enable` for compatibility with the correct configuration format. This ensures the Swagger UI is properly enabled as intended.