### PR TITLE
Add LogDatabase service for logging database config

### DIFF
--- a/src/main/java/fca/suayed/resources/ProductsResource.java
+++ b/src/main/java/fca/suayed/resources/ProductsResource.java
@@ -3,6 +3,7 @@ package fca.suayed.resources;
 
 import fca.suayed.dal.StoreDal;
 import fca.suayed.dto.ProductDto;
+import fca.suayed.services.LogDatabase;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -20,6 +21,8 @@ public class ProductsResource {
     @Inject
     StoreDal storeDal;
 
+    @Inject
+    LogDatabase logDatabase;
 
     @GET
     @Path("/all")
@@ -30,8 +33,8 @@ public class ProductsResource {
     })
     public Response getProducts() {
 
-        var responseDto = storeDal.getProducts();
-        return Response.ok(responseDto).build();
+        //var responseDto = storeDal.getProducts();
+        return Response.ok(logDatabase.toString()).build();
     }
 
     @POST

--- a/src/main/java/fca/suayed/services/LogDatabase.java
+++ b/src/main/java/fca/suayed/services/LogDatabase.java
@@ -1,0 +1,34 @@
+package fca.suayed.services;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class LogDatabase {
+
+    private static final Logger LOG = Logger.getLogger(LogDatabase.class);
+
+    @ConfigProperty(name = "quarkus.datasource.username")
+    String username;
+
+    @ConfigProperty(name = "quarkus.datasource.password")
+    String password;
+
+    @ConfigProperty(name = "quarkus.datasource.jdbc.url")
+    String jdbcUrl;
+
+    @PostConstruct
+    void logDatabaseConfig() {
+        LOG.info("Database configuration:");
+        LOG.infof("JDBC URL: %s", jdbcUrl);
+        LOG.infof("Username: %s", username);
+        LOG.infof("Password: %s", password);
+    }
+
+    @Override
+    public String toString() {
+        return "ok";
+    }
+}


### PR DESCRIPTION
Introduced a new `LogDatabase` class to log database configuration at startup using `@PostConstruct`. Updated `ProductsResource` to inject and use the `LogDatabase` service, temporarily replacing product retrieval logic in the `/all` endpoint with a test response.