### PR TITLE
Add LogDatabase service for logging database config

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.datasource.db-kind = postgresql
 
 
 quarkus.datasource.username = ${DB_USERNAME}
-quarkus.datasource.password= = ${DB_PASSWORD}
+quarkus.datasource.password = ${DB_PASSWORD}
 quarkus.datasource.jdbc.url = ${DB_URL}
 
 quarkus.swagger-ui.enable=true


### PR DESCRIPTION
Introduced a new `LogDatabase` class to log database configuration at startup using `@PostConstruct`. Updated `ProductsResource` to inject and use the `LogDatabase` service, temporarily replacing product retrieval logic in the `/all` endpoint with a test response.